### PR TITLE
add example with images

### DIFF
--- a/examples/src/Router.tsx
+++ b/examples/src/Router.tsx
@@ -13,6 +13,7 @@ import { Index } from "./pages/Index";
 import { NodeSize } from "./pages/NodeSize";
 import { SankeyDiagram } from "./pages/SankeyDiagram";
 import { TabularData } from "./pages/TabularData";
+import { WithImages } from "./pages/WithImages";
 
 const location = new ReactLocation();
 
@@ -52,6 +53,12 @@ export const routes: Route[] = [
     title: "Associative Model",
     path: "/associative-model",
     element: <AssociativeModel />,
+    type: "cyto",
+  },
+  {
+    title: "With Images",
+    path: "/with-images",
+    element: <WithImages />,
     type: "cyto",
   },
   {

--- a/examples/src/pages/WithImages.tsx
+++ b/examples/src/pages/WithImages.tsx
@@ -1,0 +1,85 @@
+import { Graph, parse, toCytoscapeElements } from "graph-selector";
+import { useEffect, useState } from "react";
+
+import { CustomEditor } from "../components/CustomEditor";
+import { CyGraph } from "../components/CyGraph";
+import { NextExample } from "../components/NextExample";
+import { ShowParsed } from "../components/ShowParsed";
+import { TitleDescription } from "../components/TitleDescription";
+import { isError } from "../utils/isError";
+
+const startingCode = `[src="https://i.ibb.co/N3r6Fy1/Screen-Shot-2023-01-11-at-2-22-31-PM.png"]
+  [src="https://i.ibb.co/xgZXHG0/Screen-Shot-2023-01-11-at-2-22-36-PM.png"]
+    [src="https://i.ibb.co/k6SgRvb/Screen-Shot-2023-01-11-at-2-22-41-PM.png"]
+      [src="https://i.ibb.co/34TTCqM/Screen-Shot-2023-01-11-at-2-22-47-PM.png"]`;
+
+export function WithImages() {
+  const [code, setCode] = useState(startingCode);
+  const [error, setError] = useState("");
+  const [parsed, setParsed] = useState<null | Graph>(null);
+  useEffect(() => {
+    try {
+      setParsed(parse(code));
+    } catch (e) {
+      setParsed(null);
+      if (isError(e)) setError(e.message);
+    }
+  }, [code]);
+
+  const elements = toCytoscapeElements(parsed);
+  return (
+    <div className="page">
+      <TitleDescription
+        pageTitle="With Images"
+        pageDescription={
+          <p>
+            Different techniques can be used to display images in different
+            contexts. This example displays an image if a "src" data attribute
+            is passed to a node.
+          </p>
+        }
+      />
+      <h2>Input</h2>
+      <CustomEditor
+        h={400}
+        value={code}
+        onChange={(newCode) => newCode && setCode(newCode)}
+      />
+      <h2>Output</h2>
+      {error ? (
+        <div className="error">{error}</div>
+      ) : (
+        <ShowParsed parsed={parsed} />
+      )}
+      <CyGraph
+        elements={elements as any}
+        style={[
+          {
+            selector: "node[src]",
+            style: {
+              "background-image": "data(src)",
+              "background-fit": "cover",
+              "background-width": "100%",
+              "background-height": "100%",
+              "background-opacity": 0.5,
+              shape: "rectangle",
+            },
+          },
+          {
+            selector: "node[src][w]",
+            style: {
+              width: "data(w)",
+            },
+          },
+          {
+            selector: "node[src][h]",
+            style: {
+              height: "data(h)",
+            },
+          },
+        ]}
+      />
+      <NextExample />
+    </div>
+  );
+}

--- a/graph-selector/src/highlight.ts
+++ b/graph-selector/src/highlight.ts
@@ -19,12 +19,12 @@ export function registerHighlighter(monaco: typeof Monaco) {
         [/^[^\n]*$/, "@rematch", "noEdge"],
       ],
       edge: [
-        [/^.*[^\\]:.*\S+.*/, "@rematch", "edgeFeatures"],
+        [/^.*[^\\]: .*\S+.*/, "@rematch", "edgeFeatures"],
         [/.*/, "@rematch", "nodeOrPointer"], // should be invalid
       ],
       noEdge: [[/.*/, "@rematch", "nodeOrPointer"]],
       edgeFeatures: [
-        [/^.*[^\\]:/, languageTokens.edgeFeatures],
+        [/^.*[^\\]: /, languageTokens.edgeFeatures],
         [/.*\S+.*$/, "@rematch", "nodeOrPointer"],
       ],
       nodeOrPointer: [

--- a/graph-selector/src/parse.test.ts
+++ b/graph-selector/src/parse.test.ts
@@ -185,7 +185,7 @@ describe("parse", () => {
   });
 
   test("should work with chinese colon and parentheses", () => {
-    const result = parse(`中文\n to：（中文）`);
+    const result = parse(`中文\n to： （中文）`);
     expect(result.edges).toEqual([
       {
         source: "n1",
@@ -217,6 +217,12 @@ describe("parse", () => {
   test("works with two-letter label pointer", () => {
     const result = parse(`bb\nc\n\t(bb)`);
     expect(result.edges.length).toEqual(1);
+  });
+
+  test("can parse node with url in attribute", () => {
+    expect(parse(`[url="http://www.google.com"]`).nodes[0].data.url).toEqual(
+      "http://www.google.com",
+    );
   });
 
   /* Edges */

--- a/graph-selector/src/parse.ts
+++ b/graph-selector/src/parse.ts
@@ -96,7 +96,7 @@ export function parse(text: string): Graph {
 
     // get edge label if parent
     let edgeLabel = "";
-    const edgeBreakIndex = line.search(/[^\\][:：]/);
+    const edgeBreakIndex = line.search(/[^\\][:：] /);
     if (edgeBreakIndex > -1) {
       edgeLabel = line.slice(0, edgeBreakIndex + 1);
       line = line.slice(edgeBreakIndex + 2).trim();


### PR DESCRIPTION
Breaking! We now require a space after a colon when separating edge information from node information.