### PR TITLE
Support containers in mermaid export

### DIFF
--- a/graph-selector/src/parse.test.ts
+++ b/graph-selector/src/parse.test.ts
@@ -453,4 +453,12 @@ a {
     expect(result.nodes[0].data.label).toEqual("");
     expect(result.nodes[1].data.parent).toEqual("n2");
   });
+
+  test("nodes that are containers should have an isParent flag", () => {
+    const result = parse(`
+a {
+  b
+}`);
+    expect(result.nodes[0].data.isParent).toEqual(true);
+  });
 });

--- a/graph-selector/src/parse.ts
+++ b/graph-selector/src/parse.ts
@@ -1,4 +1,4 @@
-import { Data, Graph, Pointer } from "./types";
+import { Data, FeatureData, Graph, Pointer } from "./types";
 import { getEdgeBreakIndex, getFeaturesIndex } from "./regexps";
 
 import { getFeatureData } from "./getFeatureData";
@@ -160,15 +160,22 @@ export function parse(text: string): Graph {
     // Store id
     nodeIds.push(id);
 
-    // create node if label is not empty
+    // create node if line declares node
     if (lineDeclaresNode) {
+      const _data: FeatureData = {
+        label,
+        id,
+        classes,
+        ...data,
+      };
+
+      // if parent, add isParent flag
+      if (isContainerStart) {
+        _data.isParent = true;
+      }
+
       const node: Graph["nodes"][number] = {
-        data: {
-          label,
-          id,
-          classes,
-          ...data,
-        },
+        data: _data,
         parser: {
           lineNumber,
         },

--- a/graph-selector/src/toMermaid.test.ts
+++ b/graph-selector/src/toMermaid.test.ts
@@ -26,10 +26,14 @@ describe("toMermaid", () => {
     expect(mermaid).toEqual(`flowchart\n\tn1[" "]`);
   });
 
-  test("supports shape classes", () => {
-    const graph = parse(`ellipse .ellipse\ncircle .circle\ndiamond .diamond\n`);
+  test("supports shapes classes", () => {
+    const graph = parse(
+      `ellipse .ellipse\ncircle .circle\ndiamond .diamond\nrounded-rectangle .rounded-rectangle\nroundedrectangle .roundedrectangle\nhexagon .hexagon\nrhomboid .rhomboid`,
+    );
     const mermaid = toMermaid(graph);
-    expect(mermaid).toEqual(`flowchart\n\tn1(["ellipse"])\n\tn2(("circle"))\n\tn3{"diamond"}`);
+    expect(mermaid).toEqual(
+      `flowchart\n\tn1(["ellipse"])\n\tn2(("circle"))\n\tn3{"diamond"}\n\tn4("rounded-rectangle")\n\tn5("roundedrectangle")\n\tn6{{"hexagon"}}\n\tn7[/"rhomboid"/]`,
+    );
   });
 
   test("Escapes characters in labels", () => {
@@ -68,5 +72,13 @@ describe("toMermaid", () => {
     expect(mermaid).toEqual(
       `flowchart\n\tsubgraph n1 ["a"]\n\t\tn2["b"]\n\tend\n\tsubgraph n5 ["c"]\n\t\tn6["d"]\n\tend\n\tn1 --> n5\n\tn6 --> n2`,
     );
+  });
+
+  test("Ignores nodes with no id", () => {
+    const mermaid = toMermaid({
+      nodes: [{ data: { label: "a", classes: "", id: "" } }],
+      edges: [],
+    });
+    expect(mermaid).toEqual(`flowchart`);
   });
 });

--- a/graph-selector/src/toMermaid.test.ts
+++ b/graph-selector/src/toMermaid.test.ts
@@ -1,0 +1,72 @@
+import { parse } from "./parse";
+import { toMermaid } from "./toMermaid";
+
+describe("toMermaid", () => {
+  test("should create nodes", () => {
+    const graph = parse(`a\nb`);
+    const mermaid = toMermaid(graph);
+    expect(mermaid).toEqual(`flowchart\n\tn1["a"]\n\tn2["b"]`);
+  });
+
+  test("should create edges", () => {
+    const graph = parse(`a\n  b`);
+    const mermaid = toMermaid(graph);
+    expect(mermaid).toEqual(`flowchart\n\tn1["a"]\n\tn2["b"]\n\tn1 --> n2`);
+  });
+
+  test("renders edge labels", () => {
+    const graph = parse(`a\n  label: b`);
+    const mermaid = toMermaid(graph);
+    expect(mermaid).toEqual(`flowchart\n\tn1["a"]\n\tn2["b"]\n\tn1 -- "label" --> n2`);
+  });
+
+  test("renders nodes with no label", () => {
+    const graph = parse(`.classonly`);
+    const mermaid = toMermaid(graph);
+    expect(mermaid).toEqual(`flowchart\n\tn1[" "]`);
+  });
+
+  test("supports shape classes", () => {
+    const graph = parse(`ellipse .ellipse\ncircle .circle\ndiamond .diamond\n`);
+    const mermaid = toMermaid(graph);
+    expect(mermaid).toEqual(`flowchart\n\tn1(["ellipse"])\n\tn2(("circle"))\n\tn3{"diamond"}`);
+  });
+
+  test("Escapes characters in labels", () => {
+    const graph = parse(`a\n  b & c < d > e \" f`);
+    const mermaid = toMermaid(graph);
+    expect(mermaid).toEqual(
+      `flowchart\n\tn1["a"]\n\tn2["b &amp; c &lt; d &gt; e &quot; f"]\n\tn1 --> n2`,
+    );
+  });
+
+  test("Supports containers / subgraphs", () => {
+    const graph = parse(`a {\n  b\n}`);
+    const mermaid = toMermaid(graph);
+    expect(mermaid).toEqual(`flowchart\n\tsubgraph n1 ["a"]\n\t\tn2["b"]\n\tend`);
+  });
+
+  test("Supports containers with edges within them", () => {
+    const graph = parse(`a {\n  b\n    c\n}`);
+    const mermaid = toMermaid(graph);
+    expect(mermaid).toEqual(
+      `flowchart\n\tsubgraph n1 ["a"]\n\t\tn2["b"]\n\t\tn3["c"]\n\tend\n\tn2 --> n3`,
+    );
+  });
+
+  test("Supports adjacent containers", () => {
+    const graph = parse(`a {\n  b\n}\nc {\n  d\n}`);
+    const mermaid = toMermaid(graph);
+    expect(mermaid).toEqual(
+      `flowchart\n\tsubgraph n1 ["a"]\n\t\tn2["b"]\n\tend\n\tsubgraph n4 ["c"]\n\t\tn5["d"]\n\tend`,
+    );
+  });
+
+  test("Supports linking between containers", () => {
+    const graph = parse(`a {\n  b\n}\n\t(c)\nc {\n  d\n    (b)\n}`);
+    const mermaid = toMermaid(graph);
+    expect(mermaid).toEqual(
+      `flowchart\n\tsubgraph n1 ["a"]\n\t\tn2["b"]\n\tend\n\tsubgraph n5 ["c"]\n\t\tn6["d"]\n\tend\n\tn1 --> n5\n\tn6 --> n2`,
+    );
+  });
+});

--- a/graph-selector/src/toMermaid.ts
+++ b/graph-selector/src/toMermaid.ts
@@ -37,7 +37,7 @@ export function toMermaid({ nodes, edges }: Graph) {
     let after = "]";
 
     // Support shape classes
-    if (classes.includes("rounded-rectangle")) {
+    if (classes.includes("rounded-rectangle") || classes.includes("roundedrectangle")) {
       before = "(";
       after = ")";
     } else if (classes.includes("ellipse")) {


### PR DESCRIPTION
- adds an `isParent` data property to any nodes which are a container parent
- supports mermaid js `subgraph` notion in to bring containers to mermaid export